### PR TITLE
:recycle: Check login/send address :like & cosmos

### DIFF
--- a/components/Modal/Send.vue
+++ b/components/Modal/Send.vue
@@ -272,7 +272,10 @@ export default {
       }
     },
     prefixValidation(address) {
-      if (address && address.startsWith(this.network.addressPrefix)) {
+      if (
+        address &&
+        (address.startsWith('like') || address.startsWith('cosmos'))
+      ) {
         return true
       } else {
         this.addressError = `prefix does not match this network's prefix`

--- a/components/Modal/Send.vue
+++ b/components/Modal/Send.vue
@@ -272,15 +272,15 @@ export default {
       }
     },
     prefixValidation(address) {
-      if (
-        address &&
-        (address.startsWith('like') || address.startsWith('cosmos'))
-      ) {
-        return true
-      } else {
-        this.addressError = `prefix does not match this network's prefix`
-        return false
+      if (address) {
+        for (let i = 0; i < this.network.allowedAddressPrefix.length; i += 1) {
+          if (address.startsWith(this.network.allowedAddressPrefix[i])) {
+            return true
+          }
+        }
       }
+      this.addressError = `prefix does not match this network's prefix`
+      return false
     },
     validatorAddressValidation(address) {
       if (address && address.includes('valoper')) {

--- a/components/Modal/Send.vue
+++ b/components/Modal/Send.vue
@@ -272,12 +272,13 @@ export default {
       }
     },
     prefixValidation(address) {
-      if (address) {
-        for (let i = 0; i < this.network.allowedAddressPrefix.length; i += 1) {
-          if (address.startsWith(this.network.allowedAddressPrefix[i])) {
-            return true
-          }
-        }
+      if (
+        address &&
+        this.network.allowedAddressPrefix.some((prefix) =>
+          address.startsWith(prefix)
+        )
+      ) {
+        return true
       }
       this.addressError = `prefix does not match this network's prefix`
       return false

--- a/network.js
+++ b/network.js
@@ -22,6 +22,7 @@ export default {
     },
   ],
   addressPrefix: 'cosmos',
+  allowedAddressPrefix: ['cosmos', 'like'],
   validatorAddressPrefix: 'cosmosvaloper',
   validatorConsensusaddressPrefix: 'cosmosvalcons', // needed to map validators from staking queries to the validator set
   HDPath: `m/44'/118'/0'/0/0`,

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -58,7 +58,7 @@ export default {
       }
     },
     prefixValidation(address) {
-      if (address.startsWith(this.network.addressPrefix)) {
+      if (address.startsWith('like') || address.startsWith('cosmos')) {
         return true
       } else {
         this.addressError = `Address is not valid for this network`

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -58,12 +58,13 @@ export default {
       }
     },
     prefixValidation(address) {
-      if (address.startsWith('like') || address.startsWith('cosmos')) {
-        return true
-      } else {
-        this.addressError = `Address is not valid for this network`
-        return false
+      for (let i = 0; i < this.network.allowedAddressPrefix.length; i += 1) {
+        if (address.startsWith(this.network.allowedAddressPrefix[i])) {
+          return true
+        }
       }
+      this.addressError = `Address is not valid for this network`
+      return false
     },
     validatorAddressValidation(address) {
       if (address.includes('valoper')) {

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -58,10 +58,13 @@ export default {
       }
     },
     prefixValidation(address) {
-      for (let i = 0; i < this.network.allowedAddressPrefix.length; i += 1) {
-        if (address.startsWith(this.network.allowedAddressPrefix[i])) {
-          return true
-        }
+      if (
+        address &&
+        this.network.allowedAddressPrefix.some((prefix) =>
+          address.startsWith(prefix)
+        )
+      ) {
+        return true
       }
       this.addressError = `Address is not valid for this network`
       return false


### PR DESCRIPTION
The original method will limit only one prefix, change to permission both prefix