### PR TITLE
💄 Add blocking UI for chain upgrade

### DIFF
--- a/components/governance/ProposalHeader.vue
+++ b/components/governance/ProposalHeader.vue
@@ -18,6 +18,7 @@
             class="action-button"
             value="Deposit"
             color="primary"
+            :disabled="disabled"
             @click.native="$emit(`open-deposit-modal`)"
           />
           <CommonButton
@@ -26,6 +27,7 @@
             class="action-button"
             value="Vote"
             color="primary"
+            :disabled="disabled"
             @click.native="$emit(`open-vote-modal`)"
           />
         </div>
@@ -89,6 +91,10 @@ export default {
     status: {
       type: Object,
       required: true,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
     },
   },
   data: () => ({

--- a/components/portfolio/Balances.vue
+++ b/components/portfolio/Balances.vue
@@ -4,7 +4,7 @@
       <h1>Your Balances</h1>
       <CommonButton
         id="claim-button"
-        :disabled="!readyToWithdraw || !balancesLoaded"
+        :disabled="!readyToWithdraw || !balancesLoaded || isChainUpgrading"
         value="Claim Rewards"
         @click.native="readyToWithdraw && openClaimModal()"
       />
@@ -20,7 +20,7 @@
         v-for="balance in sortedBalances"
         :key="balance.id"
         :balance="balance"
-        :send="true"
+        :send="!isChainUpgrading"
         @open-send-modal="openSendModal(balance.denom)"
       />
     </CommonTableContainer>
@@ -139,6 +139,9 @@ export default {
           value: `available`,
         },
       ]
+    },
+    isChainUpgrading() {
+      return !!network.isChainUpgrading
     },
   },
   methods: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,6 +24,7 @@ export default {
   mounted() {
     const session = this.$cookies.get('lunie-session')
     this.$store.dispatch('signIn', session) // calls 'data/refresh' to load the users data
+    this.$store.dispatch('data/setChainUpgradeAlert') // shows warning message if the network config 'isChainUpgrading' is true
   },
 }
 </script>

--- a/network.js
+++ b/network.js
@@ -52,4 +52,5 @@ export default {
   // This is only to be used as a developer tool and for testing purposes
   // NEVER ENABLE LOCALSIGNING IN PRODUCTION OR FOR MAINNETS
   localSigning: false,
+  isChainUpgrading: false,
 }

--- a/pages/proposals/_id.vue
+++ b/pages/proposals/_id.vue
@@ -7,6 +7,7 @@
       <GovernanceProposalHeader
         :proposal="proposal"
         :status="status"
+        :disabled="isChainUpgrading"
         @open-vote-modal="onVote"
         @open-deposit-modal="onDeposit"
       />
@@ -67,6 +68,7 @@ import {
   governanceStatusEnum,
 } from '~/common/proposal-status'
 import network from '~/common/network'
+import networkConfig from '~/network'
 
 export default {
   name: `PageProposal`,
@@ -138,6 +140,9 @@ export default {
         this.proposal.detailedVotes &&
         this.status.value === governanceStatusEnum.DEPOSITING
       )
+    },
+    isChainUpgrading() {
+      return !!networkConfig.isChainUpgrading
     },
   },
   watch: {

--- a/pages/validators/_address.vue
+++ b/pages/validators/_address.vue
@@ -31,15 +31,19 @@
           </div>
         </div>
         <div class="action-buttons">
-          <CommonButton :value="`Stake`" @click.native="openStakeModal" />
           <CommonButton
-            :disabled="!delegation"
+            :disabled="isChainUpgrading"
+            :value="`Stake`"
+            @click.native="openStakeModal"
+          />
+          <CommonButton
+            :disabled="!delegation || isChainUpgrading"
             :value="`Unstake`"
             type="secondary"
             @click.native="openUnstakeModal"
           />
           <CommonButton
-            :disabled="!delegation"
+            :disabled="!delegation || isChainUpgrading"
             :value="`Restake`"
             type="secondary"
             @click.native="openRestakeModal"
@@ -159,6 +163,7 @@ import { shortDecimals, fullDecimals, percent } from '~/common/numbers'
 import { noBlanks } from '~/common/strings'
 import { date, fromNow } from '~/common/time'
 import network from '~/common/network'
+import networkConfig from '~/network'
 
 export default {
   name: `PageValidator`,
@@ -198,6 +203,9 @@ export default {
       return this.rewards.filter(
         ({ validator: { operatorAddress } }) => operatorAddress === this.address
       )
+    },
+    isChainUpgrading() {
+      return !!networkConfig.isChainUpgrading
     },
   },
   watch: {

--- a/store/data.js
+++ b/store/data.js
@@ -1,5 +1,6 @@
 import { keyBy, uniqBy } from 'lodash'
 import network from '~/common/network'
+import networkConfig from '~/network'
 // import DataSource from '~/apis/cosmos-source-0.39'
 import DataSource from '~/apis/cosmos-source'
 import { updateValidatorImages } from '~/common/keybase'
@@ -312,6 +313,21 @@ export const actions = {
         { root: true }
       )
     }
+    return []
+  },
+  setChainUpgradeAlert({ commit }) {
+    if (networkConfig.isChainUpgrading) {
+      commit(
+        'notifications/add',
+        {
+          type: 'warning',
+          message:
+            'LikeCoin chain is being upgraded.During this period, some services may be affected until the upgrade is completed.',
+        },
+        { root: true }
+      )
+    }
+
     return []
   },
   async getAccountInfo({ state: { api } }, address) {


### PR DESCRIPTION
Show warning message and disable the following actions when chain upgrading:
- claim
- send
- stake / unstake / restake
- vote / deposit


<img width="1437" alt="截圖 2022-07-19 下午10 18 05" src="https://user-images.githubusercontent.com/75730405/179775008-1952a314-238b-43c4-bc43-0b61a34084b3.png">