### PR TITLE
🥅 Catch ibc channel not found error

### DIFF
--- a/apis/cosmos-source.js
+++ b/apis/cosmos-source.js
@@ -523,8 +523,8 @@ export default class CosmosAPI {
       chunk(trace.path.split('/'), 2).map(async ([port, channel]) => {
         const result = await this.get(
           `/ibc/core/channel/v1/channels/${channel}/ports/${port}/client_state`
-        )
-        return result.identified_client_state.client_state.chain_id
+        ).catch((_) => undefined)
+        return result ? result.identified_client_state.client_state.chain_id : null;
       })
     )
     return {


### PR DESCRIPTION
An example input would be `transfer/channel-3/transfer/channel-0/transfer/channel-217` which chunks into `[channel-3, channel-0, channel-217]`. The third one causes a 404, only the first one is useful though