### PR TITLE
💩 Hotfix proposal page due to gov v1 breaking change

### DIFF
--- a/apis/cosmos-source.js
+++ b/apis/cosmos-source.js
@@ -371,6 +371,21 @@ export default class CosmosAPI {
     return orderBy(proposals, 'id', 'desc')
   }
 
+  async getProposal(proposalId) {
+    const [
+      proposalResponse,
+      { pool },
+    ] = await Promise.all([
+      this.query(`cosmos/gov/v1beta1/proposals/${proposalId}`),
+      this.query('cosmos/staking/v1beta1/pool'),
+    ])
+    const proposal = this.reducers.proposalReducer(
+      proposalResponse.proposal || {},
+      pool.bonded_tokens,
+    )
+    return proposal;
+  }
+
   async getProposalDetails(proposal) {
     const [
       { tally_params: tallyParams },

--- a/pages/proposals/_id.vue
+++ b/pages/proposals/_id.vue
@@ -150,8 +150,11 @@ export default {
       this.getProposalDetails()
     },
   },
-  mounted() {
-    this.$store.dispatch('data/getProposals')
+  async mounted() {
+    await this.$store.dispatch('data/getProposals')
+    if (!this.proposal) {
+      await this.$store.dispatch('data/getProposal', this.proposalId)
+    }
     if (this.proposal) {
       this.getProposalDetails()
     }

--- a/store/data.js
+++ b/store/data.js
@@ -42,6 +42,9 @@ export const mutations = {
       ]
     })
   ),
+  appendProposal(state, proposal) {
+    state.proposals.push(proposal)
+  },
   setTransactions(state, { transactions, pageNumber }) {
     if (pageNumber > 0) {
       state.transactions = uniqBy(
@@ -243,6 +246,22 @@ export const actions = {
         {
           type: 'danger',
           message: 'Getting proposals failed:' + err.message,
+        },
+        { root: true }
+      )
+    }
+  },
+  async getProposal({ commit, state: { api } }, proposalId) {
+    try {
+      const proposal = await api.getProposal(proposalId)
+      commit('appendProposal', proposal)
+      commit('setProposalsLoaded', true)
+    } catch (err) {
+      commit(
+        'notifications/add',
+        {
+          type: 'danger',
+          message: 'Getting proposal failed:' + err.message,
         },
         { root: true }
       )


### PR DESCRIPTION
/proposal endpoint breaks if there exist more than 1 v1 gov proposal
hack is to fetch from /proposal/${id} in per proposal page if no proposals exists in store
proposal listing page is still broken though